### PR TITLE
Draw2dgl with go gl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ all:	install test
 
 install:
 	cd draw2d && go install
-#	cd draw2dgl && make install
+	cd draw2dgl && go install
 	cd postscript && go install
 #	cd wingui && make install
 
 build:
 	cd draw2d && go build
-#	cd draw2dgl && make build
+	cd draw2dgl && go build
 	cd postscript && go build
 #	cd wingui && make build
 
 test:
-	#cd cmd && go build draw2dgl.go
+	cd cmd && go build draw2dgl.go
 	cd cmd && go build gettingStarted.go
 	cd cmd && go build testandroid.go
 	cd cmd && go build testdraw2d.go

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -118,25 +118,7 @@ type GraphicContext struct {
 	strokeRasterizer *raster.Rasterizer
 }
 
-type Vertex struct {
-	x, y float64
-}
-
-func NewVertex() *Vertex {
-	return &Vertex{}
-}
-
-func (*Vertex) NextCommand(cmd draw2d.VertexCommand) {
-
-}
-
-func (*Vertex) Vertex(x, y float64) {
-	gl.Vertex2d(x, y)
-}
-
-/**
- * Create a new Graphic context from an image
- */
+// NewGraphicContext creates a new Graphic context from an image.
 func NewGraphicContext(width, height int) *GraphicContext {
 	gc := &GraphicContext{
 		draw2d.NewStackGraphicContext(),

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -1,15 +1,19 @@
 package draw2dgl
 
 import (
-	"gl"
 	"image"
 	"image/color"
 	"image/draw"
+	"runtime"
 
 	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/llgcode/draw2d/draw2d"
-	//"log"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 type GLPainter struct {
 	// The Porter-Duff composition operator.
@@ -71,11 +75,11 @@ func (p *GLPainter) Flush() {
 	if len(p.vertices) != 0 {
 		gl.EnableClientState(gl.COLOR_ARRAY)
 		gl.EnableClientState(gl.VERTEX_ARRAY)
-		gl.ColorPointer(4, 0, p.colors)
-		gl.VertexPointer(2, 0, p.vertices)
+		gl.ColorPointer(4, gl.UNSIGNED_BYTE, 0, gl.Ptr(p.colors))
+		gl.VertexPointer(2, gl.INT, 0, gl.Ptr(p.vertices))
 
 		// draw lines
-		gl.DrawArrays(gl.LINES, 0, len(p.vertices)/2)
+		gl.DrawArrays(gl.LINES, 0, int32(len(p.vertices)/2))
 		gl.DisableClientState(gl.VERTEX_ARRAY)
 		gl.DisableClientState(gl.COLOR_ARRAY)
 		p.vertices = p.vertices[0:0]
@@ -141,6 +145,28 @@ func NewGraphicContext(width, height int) *GraphicContext {
 		raster.NewRasterizer(width, height),
 	}
 	return gc
+}
+
+func (gc *GraphicContext) CreateStringPath(s string, x, y float64) float64 {
+	panic("not implemented")
+}
+
+func (gc *GraphicContext) FillStringAt(text string, x, y float64) (cursor float64) {
+	panic("not implemented")
+}
+
+func (gc *GraphicContext) GetStringBounds(s string) (left, top, right, bottom float64) {
+	panic("not implemented")
+}
+
+func (gc *GraphicContext) StrokeString(text string) (cursor float64) {
+	return gc.StrokeStringAt(text, 0, 0)
+}
+
+func (gc *GraphicContext) StrokeStringAt(text string, x, y float64) (cursor float64) {
+	width := gc.CreateStringPath(text, x, y)
+	gc.Stroke()
+	return width
 }
 
 func (gc *GraphicContext) SetDPI(dpi int) {

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -15,7 +15,7 @@ func init() {
 	runtime.LockOSThread()
 }
 
-type GLPainter struct {
+type Painter struct {
 	// The Porter-Duff composition operator.
 	Op draw.Op
 	// The 16-bit color to paint the spans.
@@ -28,7 +28,7 @@ type GLPainter struct {
 const M16 uint32 = 1<<16 - 1
 
 // Paint satisfies the Painter interface by painting ss onto an image.RGBA.
-func (p *GLPainter) Paint(ss []raster.Span, done bool) {
+func (p *Painter) Paint(ss []raster.Span, done bool) {
 	//gl.Begin(gl.LINES)
 	sslen := len(ss)
 	clenrequired := sslen * 8
@@ -71,7 +71,7 @@ func (p *GLPainter) Paint(ss []raster.Span, done bool) {
 	}
 }
 
-func (p *GLPainter) Flush() {
+func (p *Painter) Flush() {
 	if len(p.vertices) != 0 {
 		gl.EnableClientState(gl.COLOR_ARRAY)
 		gl.EnableClientState(gl.VERTEX_ARRAY)
@@ -88,7 +88,7 @@ func (p *GLPainter) Flush() {
 }
 
 // SetColor sets the color to paint the spans.
-func (p *GLPainter) SetColor(c color.Color) {
+func (p *Painter) SetColor(c color.Color) {
 	r, g, b, a := c.RGBA()
 	if a == 0 {
 		p.cr = 0
@@ -104,8 +104,8 @@ func (p *GLPainter) SetColor(c color.Color) {
 }
 
 // NewRGBAPainter creates a new RGBAPainter for the given image.
-func NewGLPainter() *GLPainter {
-	p := new(GLPainter)
+func NewPainter() *Painter {
+	p := new(Painter)
 	p.vertices = make([]int32, 0, 1024)
 	p.colors = make([]uint8, 0, 1024)
 	return p
@@ -113,24 +113,24 @@ func NewGLPainter() *GLPainter {
 
 type GraphicContext struct {
 	*draw2d.StackGraphicContext
-	painter          *GLPainter
+	painter          *Painter
 	fillRasterizer   *raster.Rasterizer
 	strokeRasterizer *raster.Rasterizer
 }
 
-type GLVertex struct {
+type Vertex struct {
 	x, y float64
 }
 
-func NewGLVertex() *GLVertex {
-	return &GLVertex{}
+func NewVertex() *Vertex {
+	return &Vertex{}
 }
 
-func (glVertex *GLVertex) NextCommand(cmd draw2d.VertexCommand) {
+func (*Vertex) NextCommand(cmd draw2d.VertexCommand) {
 
 }
 
-func (glVertex *GLVertex) Vertex(x, y float64) {
+func (*Vertex) Vertex(x, y float64) {
 	gl.Vertex2d(x, y)
 }
 
@@ -140,7 +140,7 @@ func (glVertex *GLVertex) Vertex(x, y float64) {
 func NewGraphicContext(width, height int) *GraphicContext {
 	gc := &GraphicContext{
 		draw2d.NewStackGraphicContext(),
-		NewGLPainter(),
+		NewPainter(),
 		raster.NewRasterizer(width, height),
 		raster.NewRasterizer(width, height),
 	}


### PR DESCRIPTION
- use `github.com/go-gl/{gl,glfw}`
- de-stutter types
- remove `GLVertex`
- add plumbing for `draw2dgl` in `Makefile`