### PR TITLE
Use github version of freetype library

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This will generate output by the different backends in the output folder.
 Acknowledgments
 ---------------
 
-[Laurent Le Goff](https://github.com/llgcode) wrote this library, inspired by [Postscript](http://www.tailrecursive.org/postscript) and [HTML5 canvas](http://www.w3.org/TR/2dcontext/). He implemented the image and opengl backend with the [freetype-go](https://code.google.com/p/freetype-go/) package. Also he created a pure go [Postscript interpreter](https://github.com/llgcode/ps), which can read postscript images and draw to a draw2d graphic context. [Stani Michiels](https://github.com/stanim) implemented the pdf backend with the [gofpdf](https://github.com/jung-kurt/gofpdf) package.
+[Laurent Le Goff](https://github.com/llgcode) wrote this library, inspired by [Postscript](http://www.tailrecursive.org/postscript) and [HTML5 canvas](http://www.w3.org/TR/2dcontext/). He implemented the image and opengl backend with the [freetype-go](https://github.com/golang/freetype/) package. Also he created a pure go [Postscript interpreter](https://github.com/llgcode/ps), which can read postscript images and draw to a draw2d graphic context. [Stani Michiels](https://github.com/stanim) implemented the pdf backend with the [gofpdf](https://github.com/jung-kurt/gofpdf) package.
 
 
 
@@ -117,5 +117,5 @@ References
 ---------
 
  - [antigrain.com](http://www.antigrain.com)
- - [freetype-go](http://code.google.com/p/freetype-go)
+ - [freetype-go](https://github.com/golang/freetype)
  -

--- a/draw2dbase/stack_gc.go
+++ b/draw2dbase/stack_gc.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/llgcode/draw2d"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var DefaultFontData = draw2d.FontData{Name: "luxi", Family: draw2d.FontFamilySans, Style: draw2d.FontStyleNormal}

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -6,8 +6,8 @@ import (
 	"image/draw"
 	"runtime"
 
-	"code.google.com/p/freetype-go/freetype/raster"
 	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/golang/freetype/raster"
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dbase"
 	"github.com/llgcode/draw2d/draw2dimg"

--- a/draw2dimg/ftgc.go
+++ b/draw2dimg/ftgc.go
@@ -14,8 +14,8 @@ import (
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dbase"
 
-	"code.google.com/p/freetype-go/freetype/raster"
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/raster"
+	"github.com/golang/freetype/truetype"
 )
 
 // Painter implements the freetype raster.Painter and has a SetColor method like the RGBAPainter

--- a/draw2dimg/ftpath.go
+++ b/draw2dimg/ftpath.go
@@ -4,7 +4,7 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/golang/freetype/raster"
 )
 
 type FtLineBuilder struct {

--- a/draw2dimg/text.go
+++ b/draw2dimg/text.go
@@ -1,7 +1,7 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 	"github.com/llgcode/draw2d"
 )
 

--- a/draw2dpdf/gc.go
+++ b/draw2dpdf/gc.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 
 	"github.com/jung-kurt/gofpdf"
 	"github.com/llgcode/draw2d"

--- a/font.go
+++ b/font.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var (

--- a/raster/raster_test.go
+++ b/raster/raster_test.go
@@ -5,7 +5,7 @@ import (
 	"image/color"
 	"testing"
 
-	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/golang/freetype/raster"
 	"github.com/llgcode/draw2d/draw2dbase"
 	"github.com/llgcode/draw2d/draw2dimg"
 )


### PR DESCRIPTION
Will fix error on `go get`
```
imports code.google.com/p/freetype-go/freetype/truetype: unable to detect version control system for code.google.com/ path
```