### PR TITLE
Update source location: code.google.com/p/freetype-go/freetype/truety…

### DIFF
--- a/draw2dbase/stack_gc.go
+++ b/draw2dbase/stack_gc.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/llgcode/draw2d"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var DefaultFontData = draw2d.FontData{Name: "luxi", Family: draw2d.FontFamilySans, Style: draw2d.FontStyleNormal}

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -6,7 +6,7 @@ import (
 	"image/draw"
 	"runtime"
 
-	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/golang/freetype/raster"
 	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dbase"

--- a/draw2dimg/ftgc.go
+++ b/draw2dimg/ftgc.go
@@ -14,8 +14,8 @@ import (
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dbase"
 
-	"code.google.com/p/freetype-go/freetype/raster"
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/raster"
+	"github.com/golang/freetype/truetype"
 )
 
 // Painter implements the freetype raster.Painter and has a SetColor method like the RGBAPainter

--- a/draw2dimg/ftpath.go
+++ b/draw2dimg/ftpath.go
@@ -4,7 +4,7 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/golang/freetype/raster"
 )
 
 type FtLineBuilder struct {

--- a/draw2dimg/text.go
+++ b/draw2dimg/text.go
@@ -1,7 +1,7 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 	"github.com/llgcode/draw2d"
 )
 

--- a/draw2dpdf/gc.go
+++ b/draw2dpdf/gc.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 
 	"github.com/jung-kurt/gofpdf"
 	"github.com/llgcode/draw2d"

--- a/font.go
+++ b/font.go
@@ -8,8 +8,7 @@ import (
 	"log"
 	"path"
 	"path/filepath"
-
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var (


### PR DESCRIPTION
…pe -> github.com/golang/freetype/truetype

Fix compilation issues caused by moved source.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>