### PR TITLE
Update code.google.com/p/freetype-go to github.com/golang/freetype. 

### DIFF
--- a/draw2dbase/stack_gc.go
+++ b/draw2dbase/stack_gc.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/llgcode/draw2d"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var DefaultFontData = draw2d.FontData{Name: "luxi", Family: draw2d.FontFamilySans, Style: draw2d.FontStyleNormal}

--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -6,8 +6,8 @@ import (
 	"image/draw"
 	"runtime"
 
-	"code.google.com/p/freetype-go/freetype/raster"
 	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/golang/freetype/raster"
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dbase"
 	"github.com/llgcode/draw2d/draw2dimg"
@@ -52,7 +52,7 @@ func (p *Painter) Paint(ss []raster.Span, done bool) {
 		vertices []int32
 	)
 	for _, s := range ss {
-		ma := s.A >> 16
+		ma := s.Alpha >> 16
 		a := uint8((ma * p.ca / M16) >> 8)
 		colors = p.colors[ci:]
 		colors[0] = p.cr

--- a/draw2dimg/ftpath.go
+++ b/draw2dimg/ftpath.go
@@ -4,7 +4,8 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/raster"
+	"github.com/golang/freetype/raster"
+	"golang.org/x/image/math/fixed"
 )
 
 type FtLineBuilder struct {
@@ -12,11 +13,11 @@ type FtLineBuilder struct {
 }
 
 func (liner FtLineBuilder) MoveTo(x, y float64) {
-	liner.Adder.Start(raster.Point{X: raster.Fix32(x * 256), Y: raster.Fix32(y * 256)})
+	liner.Adder.Start(fixed.Point26_6{X: fixed.Int26_6(x * 64), Y: fixed.Int26_6(y * 64)})
 }
 
 func (liner FtLineBuilder) LineTo(x, y float64) {
-	liner.Adder.Add1(raster.Point{X: raster.Fix32(x * 256), Y: raster.Fix32(y * 256)})
+	liner.Adder.Add1(fixed.Point26_6{X: fixed.Int26_6(x * 64), Y: fixed.Int26_6(y * 64)})
 }
 
 func (liner FtLineBuilder) LineJoin() {

--- a/draw2dimg/text.go
+++ b/draw2dimg/text.go
@@ -1,8 +1,10 @@
 package draw2dimg
 
 import (
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 	"github.com/llgcode/draw2d"
+
+	"golang.org/x/image/math/fixed"
 )
 
 // DrawContour draws the given closed contour at the given sub-pixel offset.
@@ -45,7 +47,7 @@ func pointToF64Point(p truetype.Point) (x, y float64) {
 	return fUnitsToFloat64(p.X), -fUnitsToFloat64(p.Y)
 }
 
-func fUnitsToFloat64(x int32) float64 {
+func fUnitsToFloat64(x fixed.Int26_6) float64 {
 	scaled := x << 2
 	return float64(scaled/256) + float64(scaled%256)/256.0
 }
@@ -70,11 +72,11 @@ type FontExtents struct {
 // Extents returns the FontExtents for a font.
 // TODO needs to read this https://developer.apple.com/fonts/TrueType-Reference-Manual/RM02/Chap2.html#intro
 func Extents(font *truetype.Font, size float64) FontExtents {
-	bounds := font.Bounds(font.FUnitsPerEm())
+	bounds := font.Bounds(fixed.Int26_6(font.FUnitsPerEm()))
 	scale := size / float64(font.FUnitsPerEm())
 	return FontExtents{
-		Ascent:  float64(bounds.YMax) * scale,
-		Descent: float64(bounds.YMin) * scale,
-		Height:  float64(bounds.YMax-bounds.YMin) * scale,
+		Ascent:  float64(bounds.Max.Y) * scale,
+		Descent: float64(bounds.Min.Y) * scale,
+		Height:  float64(bounds.Max.Y-bounds.Min.Y) * scale,
 	}
 }

--- a/draw2dpdf/gc.go
+++ b/draw2dpdf/gc.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 
 	"github.com/jung-kurt/gofpdf"
 	"github.com/llgcode/draw2d"

--- a/font.go
+++ b/font.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype/truetype"
 )
 
 var (


### PR DESCRIPTION
Update code.google.com/p/freetype-go to github.com/golang/freetype. Fixes #86.

Updates the dependency, as well as other changes needed to support the newer version of freetype.