### PR TITLE
draw2d.FontCache

### DIFF
--- a/font.go
+++ b/font.go
@@ -11,12 +11,6 @@ import (
 	"github.com/golang/freetype/truetype"
 )
 
-var (
-	fontFolder               = "../resource/font/"
-	fonts                    = make(map[string]*truetype.Font)
-	fontNamer  FontFileNamer = FontFileName
-)
-
 // FontStyle defines bold and italic styles for the font
 // It is possible to combine values for mixed styles, eg.
 //     FontData.Style = FontStyleBold | FontStyleItalic


### PR DESCRIPTION
Hi all,

I'd like to submit this change which gives more flexibility to customize how fonts are managed by the draw2d package.

Basically the idea is to introduce the `draw2d.FontCache` interface and `draw2d.SetFontCache` function to change the low-level behavior of storing and loading fonts.

The default implementation of this interface mimics the current behavior of the package to be backward compatible.

Here's a trace of a test run after the changes:
```
$ go test ./...
ok      github.com/achille-roussel/draw2d       0.177s
ok      github.com/achille-roussel/draw2d/draw2dbase    0.101s
?       github.com/achille-roussel/draw2d/draw2dgl      [no test files]
?       github.com/achille-roussel/draw2d/draw2dimg     [no test files]
ok      github.com/achille-roussel/draw2d/draw2dkit     0.011s
ok      github.com/achille-roussel/draw2d/draw2dpdf     0.130s
?       github.com/achille-roussel/draw2d/samples       [no test files]
?       github.com/achille-roussel/draw2d/samples/android       [no test files]
?       github.com/achille-roussel/draw2d/samples/frameimage    [no test files]
?       github.com/achille-roussel/draw2d/samples/geometry      [no test files]
?       github.com/achille-roussel/draw2d/samples/gopher        [no test files]
?       github.com/achille-roussel/draw2d/samples/gopher2       [no test files]
?       github.com/achille-roussel/draw2d/samples/helloworld    [no test files]
?       github.com/achille-roussel/draw2d/samples/helloworldgl  [no test files]
?       github.com/achille-roussel/draw2d/samples/line  [no test files]
?       github.com/achille-roussel/draw2d/samples/linecapjoin   [no test files]
?       github.com/achille-roussel/draw2d/samples/postscript    [no test files]
?       github.com/achille-roussel/draw2d/samples/postscriptgl  [no test files]
```

Please take a look at it and let me know if you would like to see anything being changed.

Cheers!