### PR TITLE
Return font set by `SetFont` if already set in `loadCurrentFont`.

### DIFF
--- a/draw2dimg/ftgc.go
+++ b/draw2dimg/ftgc.go
@@ -141,6 +141,9 @@ func (gc *GraphicContext) StrokeStringAt(text string, x, y float64) (cursor floa
 }
 
 func (gc *GraphicContext) loadCurrentFont() (*truetype.Font, error) {
+	if gc.Current.Font != nil {
+		return gc.Current.Font, nil
+	}
 	font := draw2d.GetFont(gc.Current.FontData)
 	if font == nil {
 		font = draw2d.GetFont(draw2dbase.DefaultFontData)


### PR DESCRIPTION
Currently `loadCurrentFont()` is called whenever we call `CreateStringPath`, if the user has called `SetFont` instead of using the built in font resolution methods, `loadCurrentFont()` will more or less ignore that.
