### PR TITLE
Add GetPath to the GraphicContext interface.

### DIFF
--- a/draw2dbase/stack_gc.go
+++ b/draw2dbase/stack_gc.go
@@ -132,8 +132,8 @@ func (gc *StackGraphicContext) BeginPath() {
 	gc.Current.Path.Clear()
 }
 
-func (gc *StackGraphicContext) CopyPath() *draw2d.Path {
-	return gc.Current.Path.Copy()
+func (gc *StackGraphicContext) GetPath() draw2d.Path {
+	return *gc.Current.Path.Copy()
 }
 
 func (gc *StackGraphicContext) IsEmpty() bool {

--- a/draw2dbase/stack_gc.go
+++ b/draw2dbase/stack_gc.go
@@ -132,6 +132,10 @@ func (gc *StackGraphicContext) BeginPath() {
 	gc.Current.Path.Clear()
 }
 
+func (gc *StackGraphicContext) CopyPath() *draw2d.Path {
+	return gc.Current.Path.Copy()
+}
+
 func (gc *StackGraphicContext) IsEmpty() bool {
 	return gc.Current.Path.IsEmpty()
 }

--- a/gc.go
+++ b/gc.go
@@ -14,7 +14,7 @@ type GraphicContext interface {
 	PathBuilder
 	// BeginPath creates a new path
 	BeginPath()
-	// CopyPath copies the current path, then returns it
+	// GetPath copies the current path, then returns it
 	GetPath() Path
 	// GetMatrixTransform returns the current transformation matrix
 	GetMatrixTransform() Matrix

--- a/gc.go
+++ b/gc.go
@@ -15,7 +15,7 @@ type GraphicContext interface {
 	// BeginPath creates a new path
 	BeginPath()
 	// CopyPath copies the current path, then returns it
-	CopyPath() *Path
+	GetPath() Path
 	// GetMatrixTransform returns the current transformation matrix
 	GetMatrixTransform() Matrix
 	// SetMatrixTransform sets the current transformation matrix

--- a/gc.go
+++ b/gc.go
@@ -14,6 +14,8 @@ type GraphicContext interface {
 	PathBuilder
 	// BeginPath creates a new path
 	BeginPath()
+	// CopyPath copies the current path, then returns it
+	CopyPath() *Path
 	// GetMatrixTransform returns the current transformation matrix
 	GetMatrixTransform() Matrix
 	// SetMatrixTransform sets the current transformation matrix


### PR DESCRIPTION
Currently you'd have to type assert on the gc to expose `StackGraphicContext.Current.Path` to be able to copy a path for later use. This change adds an option to simply copy and return the current path.

You can see this utilized in [cache2d](https://github.com/redstarcoder/cache2d).