### PR TITLE
Factor in kerning when using cached glyphs

### DIFF
--- a/draw2dgl/gc.go
+++ b/draw2dgl/gc.go
@@ -204,13 +204,24 @@ func (gc *GraphicContext) FillString(text string) (width float64) {
 
 // FillStringAt draws the text at the specified point (x, y)
 func (gc *GraphicContext) FillStringAt(text string, x, y float64) (width float64) {
-	xorig := x
+	f, err := gc.loadCurrentFont()
+	if err != nil {
+		log.Println(err)
+		return 0.0
+	}
+	startx := x
+	prev, hasPrev := truetype.Index(0), false
 	fontName := gc.GetFontName()
 	for _, r := range text {
+		index := f.Index(r)
+		if hasPrev {
+			x += fUnitsToFloat64(f.Kern(fixed.Int26_6(gc.Current.Scale), prev, index))
+		}
 		glyph := draw2dbase.FetchGlyph(gc, fontName, r)
 		x += glyph.Fill(gc, x, y)
+		prev, hasPrev = index, true
 	}
-	return x - xorig
+	return x - startx
 }
 
 // GetStringBounds returns the approximate pixel bounds of the string s at x, y.
@@ -259,13 +270,24 @@ func (gc *GraphicContext) StrokeString(text string) (width float64) {
 
 // StrokeStringAt draws the contour of the text at point (x, y)
 func (gc *GraphicContext) StrokeStringAt(text string, x, y float64) (width float64) {
-	xorig := x
+	f, err := gc.loadCurrentFont()
+	if err != nil {
+		log.Println(err)
+		return 0.0
+	}
+	startx := x
+	prev, hasPrev := truetype.Index(0), false
 	fontName := gc.GetFontName()
 	for _, r := range text {
+		index := f.Index(r)
+		if hasPrev {
+			x += fUnitsToFloat64(f.Kern(fixed.Int26_6(gc.Current.Scale), prev, index))
+		}
 		glyph := draw2dbase.FetchGlyph(gc, fontName, r)
 		x += glyph.Stroke(gc, x, y)
+		prev, hasPrev = index, true
 	}
-	return x - xorig
+	return x - startx
 }
 
 // recalc recalculates scale and bounds values from the font size, screen

--- a/draw2dimg/ftgc.go
+++ b/draw2dimg/ftgc.go
@@ -123,13 +123,24 @@ func (gc *GraphicContext) FillString(text string) (width float64) {
 
 // FillStringAt draws the text at the specified point (x, y)
 func (gc *GraphicContext) FillStringAt(text string, x, y float64) (width float64) {
-	xorig := x
+	f, err := gc.loadCurrentFont()
+	if err != nil {
+		log.Println(err)
+		return 0.0
+	}
+	startx := x
+	prev, hasPrev := truetype.Index(0), false
 	fontName := gc.GetFontName()
 	for _, r := range text {
+		index := f.Index(r)
+		if hasPrev {
+			x += fUnitsToFloat64(f.Kern(fixed.Int26_6(gc.Current.Scale), prev, index))
+		}
 		glyph := draw2dbase.FetchGlyph(gc, fontName, r)
 		x += glyph.Fill(gc, x, y)
+		prev, hasPrev = index, true
 	}
-	return x - xorig
+	return x - startx
 }
 
 // StrokeString draws the contour of the text at point (0, 0)
@@ -139,13 +150,24 @@ func (gc *GraphicContext) StrokeString(text string) (width float64) {
 
 // StrokeStringAt draws the contour of the text at point (x, y)
 func (gc *GraphicContext) StrokeStringAt(text string, x, y float64) (width float64) {
-	xorig := x
+	f, err := gc.loadCurrentFont()
+	if err != nil {
+		log.Println(err)
+		return 0.0
+	}
+	startx := x
+	prev, hasPrev := truetype.Index(0), false
 	fontName := gc.GetFontName()
 	for _, r := range text {
+		index := f.Index(r)
+		if hasPrev {
+			x += fUnitsToFloat64(f.Kern(fixed.Int26_6(gc.Current.Scale), prev, index))
+		}
 		glyph := draw2dbase.FetchGlyph(gc, fontName, r)
 		x += glyph.Stroke(gc, x, y)
+		prev, hasPrev = index, true
 	}
-	return x - xorig
+	return x - startx
 }
 
 func (gc *GraphicContext) loadCurrentFont() (*truetype.Font, error) {


### PR DESCRIPTION
This should fix #119, needs to be tested (already been benched, these changes don't seem to affect benchmarks in any meaningful way).
