### PR TITLE
Fixed ClearRect unable to clear transparent image

### DIFF
--- a/draw2dimg/ftgc.go
+++ b/draw2dimg/ftgc.go
@@ -99,7 +99,7 @@ func (gc *GraphicContext) Clear() {
 // ClearRect fills the current canvas with a default transparent color at the specified rectangle
 func (gc *GraphicContext) ClearRect(x1, y1, x2, y2 int) {
 	imageColor := image.NewUniform(gc.Current.FillColor)
-	draw.Draw(gc.img, image.Rect(x1, y1, x2, y2), imageColor, image.ZP, draw.Over)
+	draw.Draw(gc.img, image.Rect(x1, y1, x2, y2), imageColor, image.ZP, draw.Src)
 }
 
 // DrawImage draws an image into dest using an affine transformation matrix, an op and a filter


### PR DESCRIPTION
Hello!

I am using draw2dimg to draw things on a transparent html5 canvas, and current implementation of ClearRect uses draw.Over operation, which is unable to clear image to a fully transparent state. I suggest using draw.Src, as it allows users to clear area with transparent pixels. IMO, for transparent images this behaviour is somewhat intuitive.
Also, this behaviour would not break existing behaviour for fully opaque clear operations.