### PR TITLE
Remove gonum/plot from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Packages using draw2d
 ---------------------
 
  - [ps](https://github.com/llgcode/ps): Postscript interpreter written in Go
- - [gonum/plot](https://github.com/gonum/plot): drawing plots in Go
  - [go.uik](https://github.com/skelterjohn/go.uik): a concurrent UI kit written in pure go.
  - [smartcrop](https://github.com/muesli/smartcrop): content aware image cropping
  - [karta](https://github.com/peterhellberg/karta): drawing Voronoi diagrams


### PR DESCRIPTION
`gonum/plot` switched to `gg` 5 years ago: https://github.com/gonum/plot/commit/af8bb8117de56d839b77db55f69bedcbe9e5da60